### PR TITLE
fix: resolve formatting issues in migration schematics

### DIFF
--- a/libs/rx-stateful/schematics/src/migrations/migrate-refreshtrigger/index.ts
+++ b/libs/rx-stateful/schematics/src/migrations/migrate-refreshtrigger/index.ts
@@ -35,7 +35,7 @@ function addWithRefetchOnTriggerImport(sourceText: string): string {
 
   if (existingImportMatch) {
     // Append to existing import
-    const existingImports = existingImportMatch[1];
+    const existingImports = existingImportMatch[1].trim();
     const newImports = existingImports.includes('withRefetchOnTrigger')
       ? existingImports
       : `${existingImports}, withRefetchOnTrigger`;

--- a/libs/rx-stateful/schematics/src/migrations/migrate-to-rx-request/index.ts
+++ b/libs/rx-stateful/schematics/src/migrations/migrate-to-rx-request/index.ts
@@ -52,10 +52,14 @@ function ensureImport(sourceText: string): string {
   // Add new import at the start, after any existing imports
   const lastImportIndex = findLastImportIndex(sourceText);
   if (lastImportIndex !== -1) {
+    // Find the end of the line for the last import
+    const endOfLine = sourceText.indexOf('\n', lastImportIndex);
+    const insertIndex = endOfLine === -1 ? lastImportIndex : endOfLine;
+    
     return (
-      sourceText.slice(0, lastImportIndex) +
-      "\nimport { rxRequest } from '@angular-kit/rx-stateful';\n" +
-      sourceText.slice(lastImportIndex)
+      sourceText.slice(0, insertIndex) +
+      "\nimport { rxRequest } from '@angular-kit/rx-stateful';" +
+      sourceText.slice(insertIndex)
     );
   }
 
@@ -64,12 +68,12 @@ function ensureImport(sourceText: string): string {
 }
 
 function findLastImportIndex(sourceText: string): number {
-  const importRegex = /^import.*?;?\s*$/gm;
+  const importRegex = /^import.*?;?/gm;
   let lastIndex = -1;
   let match;
 
   while ((match = importRegex.exec(sourceText)) !== null) {
-    lastIndex = match.index + match[0].length;
+    lastIndex = match.index;
   }
 
   return lastIndex;


### PR DESCRIPTION
## Summary
- Fixed failing test cases in the migration schematics
- Resolved formatting issues that were causing test failures

## Changes Made
1. **migrate-to-rx-request migration**: Fixed trailing whitespace issue when inserting imports after existing imports
2. **migrate-refreshtrigger migration**: Fixed import formatting issue where extra spaces were being added around imported symbols

## Test Plan
- [x] Run `npx nx test rx-stateful` - all 61 tests passing
- [x] Run `npx nx lint rx-stateful` - no linting errors
- [x] Verified both migration schematics generate correct output without formatting issues

Fixes #18

🤖 Generated with [Claude Code](https://claude.ai/code)