### PR TITLE
refactor: Use sidenav instead of mat-tab-nav-bar in NavigationComponent (#35)

### DIFF
--- a/apps/demo/src/app/app.component.ts
+++ b/apps/demo/src/app/app.component.ts
@@ -8,22 +8,20 @@ import { BehaviorSubject, map, of, scan, Subject, timer } from 'rxjs';
   imports: [RouterModule, NavigationComponent],
   selector: 'demo-root',
   template: `
-    <h1>RxStateful Demo</h1>
-    <p>Select one of the demos from the tabs below</p>
     <navigation />
 
-    <!--    <button (click)="refresh$$.next()">Refresh</button>-->
-    <!--    <button (click)="page$$.next(1)">next page</button>-->
-    <!--    {{ req.value$() | async | json }}-->
-    <!--    <br>-->
-    <!--    <hr>-->
-    <!--    {{ req2.value$() | async | json }}-->
+<!--    <button (click)="refresh$$.next()">Refresh</button>-->
+<!--    <button (click)="page$$.next(1)">next page</button>-->
+<!--    {{ req.value$() | async | json }}-->
+<!--    <br>-->
+<!--    <hr>-->
+<!--    {{ req2.value$() | async | json }}-->
   `,
-  styles: [
-    `
+    styles: [
+        `
       :host {
         display: block;
-        padding: 32px 64px 32px 64px;
+        height: 100vh;
       }
     `,
   ],

--- a/apps/demo/src/app/navigation.component.ts
+++ b/apps/demo/src/app/navigation.component.ts
@@ -6,7 +6,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { BreakpointObserver } from '@angular/cdk/layout';
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, NgIf } from '@angular/common';
 import { filter, map, shareReplay } from 'rxjs';
 
 import {appRoutes} from "./app.routes";
@@ -19,7 +19,8 @@ import {appRoutes} from "./app.routes";
         MatIconModule,
         MatButtonModule,
         MatToolbarModule,
-        AsyncPipe
+        AsyncPipe,
+        NgIf
     ],
     selector: 'navigation',
     template: `

--- a/apps/demo/src/app/navigation.component.ts
+++ b/apps/demo/src/app/navigation.component.ts
@@ -1,32 +1,121 @@
-import { Component } from '@angular/core';
-import { RouterModule } from '@angular/router';
-import {MatTabsModule} from "@angular/material/tabs";
+import { Component, ViewChild } from '@angular/core';
+import { RouterModule, Router, NavigationEnd } from '@angular/router';
+import { MatSidenavModule, MatSidenav } from '@angular/material/sidenav';
+import { MatListModule } from '@angular/material/list';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { BreakpointObserver } from '@angular/cdk/layout';
+import { AsyncPipe } from '@angular/common';
+import { filter, map, shareReplay } from 'rxjs';
 
 import {appRoutes} from "./app.routes";
 
 @Component({
-    imports: [RouterModule, MatTabsModule],
+    imports: [
+        RouterModule,
+        MatSidenavModule,
+        MatListModule,
+        MatIconModule,
+        MatButtonModule,
+        MatToolbarModule,
+        AsyncPipe
+    ],
     selector: 'navigation',
     template: `
-    <nav mat-tab-nav-bar  [tabPanel]="tabPanel">
-      @for (link of links; track link) {
-        <a mat-tab-link
-          (click)="activeLink = link"
-          [active]="activeLink == link"
-        [routerLink]="link.path"> {{link.title}} </a>
-      }
-    
-    </nav>
-    <mat-tab-nav-panel #tabPanel>
-      <router-outlet></router-outlet>
-    </mat-tab-nav-panel>
+    <mat-sidenav-container class="sidenav-container">
+      <mat-sidenav #drawer class="sidenav"
+        [attr.role]="(isHandset$ | async) ? 'dialog' : 'navigation'"
+        [mode]="(isHandset$ | async) ? 'over' : 'side'"
+        [opened]="(isHandset$ | async) === false">
+        <mat-toolbar>Menu</mat-toolbar>
+        <mat-nav-list>
+          @for (link of links; track link.path) {
+            <a mat-list-item
+              [routerLink]="link.path"
+              routerLinkActive="active-link"
+              [routerLinkActiveOptions]="{exact: true}">
+              {{link.title}}
+            </a>
+          }
+        </mat-nav-list>
+      </mat-sidenav>
+
+      <mat-sidenav-content>
+        <mat-toolbar color="primary">
+          <button
+            type="button"
+            aria-label="Toggle sidenav"
+            mat-icon-button
+            (click)="drawer.toggle()"
+            *ngIf="isHandset$ | async">
+            <mat-icon aria-label="Side nav toggle icon">menu</mat-icon>
+          </button>
+          <span>RxStateful Demos</span>
+        </mat-toolbar>
+
+        <div class="content-container">
+          <router-outlet></router-outlet>
+        </div>
+      </mat-sidenav-content>
+    </mat-sidenav-container>
     `,
-    styles: [``]
+    styles: [`
+      .sidenav-container {
+        height: 100%;
+      }
+
+      .sidenav {
+        width: 250px;
+      }
+
+      .sidenav .mat-toolbar {
+        background: inherit;
+      }
+
+      .mat-toolbar.mat-primary {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+      }
+
+      .content-container {
+        padding: 20px;
+      }
+
+      .active-link {
+        background-color: rgba(0, 0, 0, 0.04);
+      }
+
+      mat-nav-list a {
+        font-size: 14px;
+        font-weight: 400;
+      }
+    `]
 })
 export class NavigationComponent {
+  @ViewChild('drawer') drawer!: MatSidenav;
 
-  title = 'demo';
-  links = appRoutes
+  links = appRoutes;
 
-  activeLink = this.links[0];
+  isHandset$ = this.breakpointObserver.observe('(max-width: 768px)')
+    .pipe(
+      map(result => result.matches),
+      shareReplay()
+    );
+
+  constructor(
+    private breakpointObserver: BreakpointObserver,
+    private router: Router
+  ) {
+    // Close sidenav on mobile after navigation
+    this.router.events.pipe(
+      filter(event => event instanceof NavigationEnd),
+      filter(() => this.breakpointObserver.isMatched('(max-width: 768px)'))
+    ).subscribe(() => {
+      if (this.drawer) {
+        this.drawer.close();
+      }
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- Replaced mat-tab-nav-bar with mat-sidenav for improved navigation UX
- Added responsive design with drawer mode for mobile devices
- Implemented automatic sidenav closing on mobile navigation

## Changes
- **NavigationComponent refactored**: Replaced tab-based navigation with a Material sidenav
- **Responsive behavior**: Sidenav uses "side" mode on desktop and "over" mode on mobile
- **Mobile-friendly**: Added hamburger menu toggle button that appears only on mobile
- **Auto-close on navigation**: Sidenav automatically closes on mobile after route navigation
- **Improved layout**: Added toolbar header with title and proper content spacing

## Test Plan
- [x] Verified navigation works for all routes
- [x] Tested responsive behavior on different screen sizes
- [x] Confirmed active link highlighting works correctly
- [x] Ensured no compilation warnings
- [x] Ran available linting (rx-stateful library)

Fixes #35

🤖 Generated with [Claude Code](https://claude.ai/code)