### PR TITLE
fix: remove redundant refetchFn() call and fragile BehaviorSubject handling

### DIFF
--- a/libs/rx-stateful/src/lib/refetch-strategies/merge-refetch-strategies.spec.ts
+++ b/libs/rx-stateful/src/lib/refetch-strategies/merge-refetch-strategies.spec.ts
@@ -1,49 +1,73 @@
-import {mergeRefetchStrategies} from "./merge-refetch-strategies";
-import {RefetchStrategy} from "./refetch-strategy";
-import {withRefetchOnTrigger} from "./refetch-on-trigger.strategy";
-import {BehaviorSubject, concatAll, mergeAll, of, ReplaySubject, Subject} from "rxjs";
-import {subscribeSpyTo} from "@hirez_io/observer-spy";
+import { mergeRefetchStrategies } from './merge-refetch-strategies';
+import { RefetchStrategy } from './refetch-strategy';
+import { withRefetchOnTrigger } from './refetch-on-trigger.strategy';
+import { BehaviorSubject, concatAll, mergeAll, of, ReplaySubject, Subject } from 'rxjs';
+import { subscribeSpyTo } from '@hirez_io/observer-spy';
+import { vi } from 'vitest';
 
 describe('mergeRefetchStrategies', () => {
-    it('should return empty array when no refetchStrategies are provided', () => {
-        expect(mergeRefetchStrategies([])).toEqual([]);
-    })
+  it('should return empty array when no refetchStrategies are provided', () => {
+    expect(mergeRefetchStrategies([])).toEqual([]);
+  });
 
-    it('should filter out null or undefined strategies', () => {
-        expect(mergeRefetchStrategies([null as unknown as RefetchStrategy, undefined as unknown as RefetchStrategy])).toEqual([]);
-    })
+  it('should filter out null or undefined strategies', () => {
+    expect(
+      mergeRefetchStrategies([null as unknown as RefetchStrategy, undefined as unknown as RefetchStrategy])
+    ).toEqual([]);
+  });
 
-    it('should return for each strategy the refetch$ observable', () => {
-        const trigger1$ = new Subject();
-        const trigger2$ = new ReplaySubject();
-        const trigger3$ = new BehaviorSubject<any>(null);
-        const strategies: RefetchStrategy[] = [
-            withRefetchOnTrigger(trigger1$),
-            withRefetchOnTrigger(trigger2$),
-            withRefetchOnTrigger(trigger3$),
-        ]
+  it('should return for each strategy the refetch$ observable', () => {
+    const trigger1$ = new Subject();
+    const trigger2$ = new ReplaySubject();
+    const trigger3$ = new BehaviorSubject<any>(null);
+    const strategies: RefetchStrategy[] = [
+      withRefetchOnTrigger(trigger1$),
+      withRefetchOnTrigger(trigger2$),
+      withRefetchOnTrigger(trigger3$),
+    ];
 
-        const refetchStrategies = mergeRefetchStrategies(strategies);
-        expect(refetchStrategies.length).toEqual(3);
+    const refetchStrategies = mergeRefetchStrategies(strategies);
+    expect(refetchStrategies.length).toEqual(3);
 
+    const result = subscribeSpyTo(of(refetchStrategies).pipe(concatAll(), mergeAll()));
 
+    trigger1$.next(10);
+    trigger2$.next(20);
+    trigger3$.next(30);
 
+    expect(result.getValues()).toEqual([10, 20, 30]);
+  });
 
-        const result = subscribeSpyTo(of(refetchStrategies).pipe(
-            concatAll(),
-            mergeAll()
-        ));
+  it('should not double-call refetchFn for each strategy', () => {
+    const refetchFnSpy = vi.fn(() => new Subject());
+    const mockStrategy: RefetchStrategy = {
+      refetchFn: refetchFnSpy,
+      kind: 'trigger__rxStateful',
+    };
 
-        trigger1$.next(10);
-        trigger2$.next(20);
-        trigger3$.next(30);
+    mergeRefetchStrategies([mockStrategy]);
 
-       // expect(first.getValues()).toEqual([10]);
-        //expect(second.getValues()).toEqual([20]);
-        //expect(third.getValues()).toEqual([ 30]);
+    // Verify refetchFn is called exactly once per strategy
+    expect(refetchFnSpy).toHaveBeenCalledTimes(1);
+  });
 
-        expect(result.getValues()).toEqual([10, 20, 30]);
+  it('should handle BehaviorSubject initial values correctly via strategy', () => {
+    // BehaviorSubject with initial value
+    const behaviorTrigger$ = new BehaviorSubject<number>(100);
+    const strategy = withRefetchOnTrigger(behaviorTrigger$);
 
-    })
-})
+    const refetchObservables = mergeRefetchStrategies([strategy]);
+    expect(refetchObservables.length).toEqual(1);
 
+    const spy = subscribeSpyTo(refetchObservables[0]);
+
+    // Should not emit the initial value (100) because withRefetchOnTrigger applies skip(1)
+    expect(spy.getValues()).toEqual([]);
+
+    // Emit a new value
+    behaviorTrigger$.next(200);
+
+    // Should only have the new value, not the initial
+    expect(spy.getValues()).toEqual([200]);
+  });
+});

--- a/libs/rx-stateful/src/lib/refetch-strategies/merge-refetch-strategies.ts
+++ b/libs/rx-stateful/src/lib/refetch-strategies/merge-refetch-strategies.ts
@@ -1,15 +1,12 @@
-import {RefetchStrategy} from "./refetch-strategy";
-import {BehaviorSubject, Observable, pipe, skip} from "rxjs";
+import { RefetchStrategy } from './refetch-strategy';
+import { Observable } from 'rxjs';
 
-
-export function mergeRefetchStrategies(refetchStrategies: RefetchStrategy[] | RefetchStrategy | undefined): Observable<any>[] {
-    if (!refetchStrategies) {
-        return [];
-    }
-    const strategies: RefetchStrategy[] = Array.isArray(refetchStrategies) ? refetchStrategies : [refetchStrategies];
-    return strategies.map(strategy => strategy?.refetchFn().pipe(
-      strategy.refetchFn() instanceof BehaviorSubject ? skip(1) : pipe(),
-    )).filter(Boolean);
-
+export function mergeRefetchStrategies(
+  refetchStrategies: RefetchStrategy[] | RefetchStrategy | undefined
+): Observable<any>[] {
+  if (!refetchStrategies) {
+    return [];
+  }
+  const strategies: RefetchStrategy[] = Array.isArray(refetchStrategies) ? refetchStrategies : [refetchStrategies];
+  return strategies.filter(Boolean).map((strategy) => strategy.refetchFn());
 }
-


### PR DESCRIPTION
## Summary
- Eliminate redundant double-call to `strategy.refetchFn()` in `mergeRefetchStrategies` function
- Remove fragile `instanceof BehaviorSubject` check that doesn't work reliably with piped observables
- Simplify implementation by letting individual strategies handle their own `skip(1)` logic

## Context
This PR addresses issue #48 which identified performance and logic issues in the `mergeRefetchStrategies` function.

## Problems Fixed
1. **Redundant Function Calls**: The function was calling `strategy.refetchFn()` twice - once for the pipe operation and once for the BehaviorSubject check. This was wasteful and could cause side effects with cold streams.

2. **Fragile BehaviorSubject Detection**: The `instanceof BehaviorSubject` check was unreliable and created unnecessary coupling between the merge logic and individual strategies.

## Changes Made
- Modified `mergeRefetchStrategies` to call `refetchFn()` only once per strategy
- Removed the BehaviorSubject instanceof check and associated skip logic
- Simplified the function to filter null/undefined strategies first, then map to observables
- Added comprehensive tests to verify single-call behavior and proper BehaviorSubject handling

## Testing
- All existing tests pass ✅
- Added new test to verify `refetchFn()` is called exactly once per strategy
- Added test to confirm BehaviorSubject initial values are still skipped correctly (handled by the strategy itself)
- Full test suite passes with no regressions

## Benefits
- Better performance (no redundant function calls)
- More reliable logic (no fragile instanceof checks)
- Cleaner separation of concerns between merge logic and individual strategies
- Simpler, more maintainable code

Fixes #48