### PR TITLE
fix: remove incorrect and unused type guards

### DIFF
--- a/libs/rx-stateful/src/lib/types/guards.ts
+++ b/libs/rx-stateful/src/lib/types/guards.ts
@@ -1,24 +1,9 @@
-import {RxStatefulConfig, SourceTriggerConfig} from "./types";
-import {isObservable, Observable, Subject} from "rxjs";
+import { SourceTriggerConfig } from './types';
 
-
-export function isObservableOrSubjectGuard(arg: any): arg is Observable<any> | Subject<any>{
-    return isObservable(arg) || arg instanceof Subject;
-}
-
-export function isRxStatefulConfigOrObsGuard<T,E>(arg: any): arg is RxStatefulConfig<T, E>{
-    // write type guard for RxStatefulConfig
-    return !(isObservableOrSubjectGuard(arg))
-}
-
-export function isRxStatefulConfigOrSourceTriggerConfigGuard<T,E>(arg: any): arg is RxStatefulConfig<T, E>{
-    // write type guard for RxStatefulConfig
-    return (arg as any)?.trigger !== undefined
-}
 export function isFunctionGuard(value: any): value is (...args: any[]) => any {
-    return typeof value === 'function';
+  return typeof value === 'function';
 }
 
-export function isSourceTriggerConfigGuard<T>(arg: any): arg is SourceTriggerConfig<T>{
-    return arg?.sourceTriggerConfig !== undefined;
+export function isSourceTriggerConfigGuard<T>(arg: any): arg is SourceTriggerConfig<T> {
+  return arg?.sourceTriggerConfig !== undefined;
 }


### PR DESCRIPTION
## Summary
- Removed dead code from guards.ts file to improve maintainability and reduce bundle size

## Changes
- Removed `isRxStatefulConfigOrObsGuard` - unused guard with generic implementation
- Removed `isRxStatefulConfigOrSourceTriggerConfigGuard` - incorrect implementation (checks for wrong property)
- Removed `isObservableOrSubjectGuard` - only used by removed guards
- Cleaned up unused imports from rxjs

## Impact
- ✅ No breaking changes - these guards were not used anywhere in the codebase
- ✅ Reduces bundle size by removing dead code
- ✅ Improves code maintainability
- ✅ All tests passing
- ✅ Linting and type checking successful

## Testing
- Verified no references to removed guards exist in codebase
- All tests pass successfully
- Build completes without errors
- Linting shows no issues

Closes #50