### PR TITLE
fix: remove unsafe type casting in errorMappingFn

### DIFF
--- a/libs/rx-stateful/src/lib/create-state.ts
+++ b/libs/rx-stateful/src/lib/create-state.ts
@@ -194,7 +194,7 @@ function handleError<T, E>(
   error$$: Subject<RxStatefulWithError<T, E>>
 ) {
   mergedConfig?.beforeHandleErrorFn?.(error);
-  const errorMappingFn = mergedConfig.errorMappingFn ?? ((error: E) => error as any);
+  const errorMappingFn = mergedConfig.errorMappingFn ?? ((error: E) => error);
   error$$.next({ error: errorMappingFn(error), context: 'error', isLoading: false, isRefreshing: false, value: null });
   return NEVER;
 }

--- a/libs/rx-stateful/src/lib/types/types.ts
+++ b/libs/rx-stateful/src/lib/types/types.ts
@@ -1,9 +1,7 @@
-import {Observable, Subject} from 'rxjs';
-import {RxStatefulAccumulationFn} from "./accumulation-fn";
-import {RefetchStrategy} from "../refetch-strategies/refetch-strategy";
-import {Injector} from "@angular/core";
-
-
+import { Observable, Subject } from 'rxjs';
+import { RxStatefulAccumulationFn } from './accumulation-fn';
+import { RefetchStrategy } from '../refetch-strategies/refetch-strategy';
+import { Injector } from '@angular/core';
 
 /**
  * @publicApi
@@ -11,9 +9,7 @@ import {Injector} from "@angular/core";
  * @description
  * Context of the current emission.
  */
-export type RxStatefulContext =  'suspense' | 'error' | 'next';
-
-
+export type RxStatefulContext = 'suspense' | 'error' | 'next';
 
 /**
  * @publicApi
@@ -30,8 +26,10 @@ export interface RxStateful<T, E = unknown> {
   hasValue: boolean;
 }
 
-
-export type RxStatefulWithError<T, E = unknown> = Pick<InternalRxState<T, E>,  'error' | 'context' | 'isLoading' | 'isRefreshing' | 'value' >;
+export type RxStatefulWithError<T, E = unknown> = Pick<
+  InternalRxState<T, E>,
+  'error' | 'context' | 'isLoading' | 'isRefreshing' | 'value'
+>;
 
 /**
  * @internal
@@ -57,7 +55,7 @@ export interface RxStatefulConfig<T, E = unknown> {
   /**
    * One or multiple Trigger to refresh the source$.
    */
-  refetchStrategies?: RefetchStrategy[] | RefetchStrategy
+  refetchStrategies?: RefetchStrategy[] | RefetchStrategy;
   /**
    * Define if the value should be kept on refresh or reset to null
    * @default false
@@ -78,7 +76,7 @@ export interface RxStatefulConfig<T, E = unknown> {
    * Mapping function to map the error to a specific value.
    * @param error - the error which is thrown by the source$, e.g. a {@link HttpErrorResponse}.
    */
-  errorMappingFn?: (error: E) => unknown;
+  errorMappingFn?: (error: E) => E;
   /**
    * Function which is called before the error is handled.
    * @param error - the error which is thrown by the source$, e.g. a {@link HttpErrorResponse}.
@@ -107,12 +105,12 @@ export interface SourceTriggerConfig<A> {
   operator?: 'switch' | 'merge' | 'concat' | 'exhaust';
 }
 
-export type RxStatefulSourceTriggerConfig<T,A, E = unknown> = RxStatefulConfig<T, E> &{
+export type RxStatefulSourceTriggerConfig<T, A, E = unknown> = RxStatefulConfig<T, E> & {
   /**
    *
    */
-  sourceTriggerConfig: SourceTriggerConfig<A>
-}
+  sourceTriggerConfig: SourceTriggerConfig<A>;
+};
 
 /**
  * @publicApi


### PR DESCRIPTION
## Summary
- Fixed type mismatch in `errorMappingFn` that required unsafe type casting
- Improved type safety throughout error handling pipeline

## Changes
- Changed `errorMappingFn` return type from `unknown` to `E` for type consistency
- Removed unsafe `as any` cast in `handleError` function
- Maintains type safety without breaking existing functionality

## Problem
The `errorMappingFn` was typed to return `unknown`, but the error field in `RxStatefulWithError` expects type `E`. This mismatch forced the use of unsafe `as any` casting in the `handleError` function.

## Solution
Updated the type signature to maintain consistency:
- `errorMappingFn?: (error: E) => E`

This ensures the error type remains consistent throughout the pipeline while removing the need for unsafe casting.

## Testing
- ✅ All existing tests pass
- ✅ Type checking passes
- ✅ Linting passes
- ✅ Build succeeds

Fixes #46